### PR TITLE
Update setup.py to support JSONDecoder for python>=3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ def _load_meta(path):
     :return: Dictionary of key value pairs.
     """
     with open(path) as f:
-        meta = load(f, encoding='utf-8')
+        meta = load(f)
         meta = {k: v.decode('utf-8') if isinstance(v, bytes) else v
                 for k, v in meta.items()}
 


### PR DESCRIPTION
Remove deprecated `encoding` kwarg.

Seems to be working. It doesn't look like you have a `CONTRIBUTING.md` so let me know if you need anything else to address this and begin a hotfix release (which would also be great to host on conda-forge btw). 

Closes #3 